### PR TITLE
Match f3fora/cmp-spell

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+indent_width = 2
+indent_type = "Spaces"
+quote_style = "AutoPreferSingle"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ A function that, upon returning false, disables the completion source. This can
 be used to disable the spelling source when in a `@nospell` `treesitter`
 capture.
 
+### `keep_all_entries` (`boolean`, default `false`)
+
+If true, all `vim.fn.spellsuggest` results are displayed in `blink`'s menu. Otherwise,
+they are being filtered to only include fuzzy matches.
+
+### `preselect_correct_word` (`boolean`, default `true`)
+
+If true and the spelling of a word is correct, the word is displayed as the first entry
+and preselected.
+
 ## Shoutout
 
 A huge thank you to @f3fora for the code inspiration from

--- a/lua/blink-cmp-spell/init.lua
+++ b/lua/blink-cmp-spell/init.lua
@@ -2,14 +2,14 @@
 
 ---@class blink-cmp-spell.Config
 local defaults = {
-	max_entries = 3,
-	---@param ctx? blink.cmp.Context
-	---@diagnostic disable: unused-local
-	enable_in_context = function(ctx)
-		return true
-	end,
-	keep_all_entries = false,
-	preselect_correct_word = true,
+  max_entries = 3,
+  ---@param ctx? blink.cmp.Context
+  ---@diagnostic disable: unused-local
+  enable_in_context = function(ctx)
+    return true
+  end,
+  keep_all_entries = false,
+  preselect_correct_word = true,
 }
 
 ---@class blink-cmp-spell.Source:  blink.cmp.Source
@@ -17,38 +17,38 @@ local M = {}
 
 M.max_entries = 0 ---@type integer
 M.enable_in_context = function() ---@type function(ctx? blink.cmp.Context): boolean
-	return true
+  return true
 end
 M.keep_all_entries = false ---@type boolean
 M.preselect_correct_word = true ---@type boolean
 
 ---@param opts? blink-cmp-spell.Config
 function M.new(opts)
-	local config = vim.tbl_deep_extend("keep", opts or {}, defaults)
-	vim.validate({
-		max_entries = { config.max_entries, "number" },
-		enable_in_context = { config.enable_in_context, "function" },
-		keep_all_entries = { config.keep_all_entries, "boolean" },
-		preselect_correct_word = { config.preselect_correct_word, "boolean" },
-	})
+  local config = vim.tbl_deep_extend('keep', opts or {}, defaults)
+  vim.validate({
+    max_entries = { config.max_entries, 'number' },
+    enable_in_context = { config.enable_in_context, 'function' },
+    keep_all_entries = { config.keep_all_entries, 'boolean' },
+    preselect_correct_word = { config.preselect_correct_word, 'boolean' },
+  })
 
-	return setmetatable({
-		max_entries = config.max_entries,
-		enable_in_context = config.enable_in_context,
-		keep_all_entries = config.keep_all_entries,
-		preselect_correct_word = config.preselect_correct_word,
-	}, { __index = M })
+  return setmetatable({
+    max_entries = config.max_entries,
+    enable_in_context = config.enable_in_context,
+    keep_all_entries = config.keep_all_entries,
+    preselect_correct_word = config.preselect_correct_word,
+  }, { __index = M })
 end
 
 ---@return boolean
 function M:enabled()
-	return vim.wo.spell
+  return vim.wo.spell
 end
 
 ---@param len integer
 ---@return integer
 local function len_to_loglen(len)
-	return math.ceil(math.log10(len + 1))
+  return math.ceil(math.log10(len + 1))
 end
 
 ---@param input string
@@ -56,64 +56,64 @@ end
 ---@param loglen integer
 ---@return string
 local function number_to_text(input, number, loglen)
-	return string.format(input .. "%0" .. loglen .. "d", number)
+  return string.format(input .. '%0' .. loglen .. 'd', number)
 end
 
 ---@param input string
 ---@param src blink-cmp-spell.Source
 ---@return table
 local function candidates(input, src)
-	local items = {}
-	local entries = vim.fn.spellsuggest(input, src.max_entries)
-	local offset
-	local loglen
-	if src.preselect_correct_word and vim.tbl_isempty(vim.spell.check(input)) then
-		offset = 1
-		loglen = len_to_loglen(#entries + offset)
+  local items = {}
+  local entries = vim.fn.spellsuggest(input, src.max_entries)
+  local offset
+  local loglen
+  if src.preselect_correct_word and vim.tbl_isempty(vim.spell.check(input)) then
+    offset = 1
+    loglen = len_to_loglen(#entries + offset)
 
-		items[offset] = {
-			label = input,
-			filterText = input,
-			sortText = number_to_text(input, offset, loglen),
-			preselct = true,
-		}
-	else
-		offset = 0
-		loglen = len_to_loglen(#entries + offset)
-	end
+    items[offset] = {
+      label = input,
+      filterText = input,
+      sortText = number_to_text(input, offset, loglen),
+      preselct = true,
+    }
+  else
+    offset = 0
+    loglen = len_to_loglen(#entries + offset)
+  end
 
-	for k, v in ipairs(entries) do
-		items[k + offset] = {
-			label = v,
-			filterText = src.keep_all_entries and input or v,
-			sortText = src.keep_all_entries and number_to_text(input, k + offset, loglen) or v,
-			preselct = false,
-		}
-	end
+  for k, v in ipairs(entries) do
+    items[k + offset] = {
+      label = v,
+      filterText = src.keep_all_entries and input or v,
+      sortText = src.keep_all_entries and number_to_text(input, k + offset, loglen) or v,
+      preselct = false,
+    }
+  end
 
-	return items
+  return items
 end
 
 ---@param context blink.cmp.Context
 ---@param callback blink.cmp.CompletionResponse
 function M:get_completions(context, callback)
-	vim.schedule(function()
-		local input =
-			string.sub(context.line, context.bounds.start_col, context.bounds.start_col + context.bounds.length - 1)
-		if self.enable_in_context(context) then
-			callback({
-				items = candidates(input, self),
-				is_incomplete_forward = true,
-				is_incomplete_backward = true,
-			})
-		else
-			callback({
-				items = {},
-				is_incomplete_forward = true,
-				is_incomplete_backward = true,
-			})
-		end
-	end)
+  vim.schedule(function()
+    local input =
+      string.sub(context.line, context.bounds.start_col, context.bounds.start_col + context.bounds.length - 1)
+    if self.enable_in_context(context) then
+      callback({
+        items = candidates(input, self),
+        is_incomplete_forward = true,
+        is_incomplete_backward = true,
+      })
+    else
+      callback({
+        items = {},
+        is_incomplete_forward = true,
+        is_incomplete_backward = true,
+      })
+    end
+  end)
 end
 
 return M

--- a/lua/blink-cmp-spell/init.lua
+++ b/lua/blink-cmp-spell/init.lua
@@ -1,74 +1,119 @@
 ---@module 'blink.cmp'
 
+---@class blink-cmp-spell.Config
 local defaults = {
-  max_entries = 3,
-  enable_in_context = function()
-    return true
-  end,
+	max_entries = 3,
+	---@param ctx? blink.cmp.Context
+	---@diagnostic disable: unused-local
+	enable_in_context = function(ctx)
+		return true
+	end,
+	keep_all_entries = false,
+	preselect_correct_word = true,
 }
 
---- @class blink-cmp-spell.Source : blink.cmp.Source
+---@class blink-cmp-spell.Source:  blink.cmp.Source
 local M = {}
 
+M.max_entries = 0 ---@type integer
+M.enable_in_context = function() ---@type function(ctx? blink.cmp.Context): boolean
+	return true
+end
+M.keep_all_entries = false ---@type boolean
+M.preselect_correct_word = true ---@type boolean
+
+---@param opts? blink-cmp-spell.Config
 function M.new(opts)
-  local config = vim.tbl_deep_extend('keep', opts or {}, defaults)
-  vim.validate {
-    max_entries = { config.max_entries, 'number' },
-    enable_in_context = { config.enable_in_context, 'function' },
-  }
+	local config = vim.tbl_deep_extend("keep", opts or {}, defaults)
+	vim.validate({
+		max_entries = { config.max_entries, "number" },
+		enable_in_context = { config.enable_in_context, "function" },
+		keep_all_entries = { config.keep_all_entries, "boolean" },
+		preselect_correct_word = { config.preselect_correct_word, "boolean" },
+	})
 
-  return setmetatable({
-    max_entries = config.max_entries,
-    enable_in_context = config.enable_in_context,
-  }, { __index = M })
+	return setmetatable({
+		max_entries = config.max_entries,
+		enable_in_context = config.enable_in_context,
+		keep_all_entries = config.keep_all_entries,
+		preselect_correct_word = config.preselect_correct_word,
+	}, { __index = M })
 end
 
+---@return boolean
 function M:enabled()
-  return vim.wo.spell
+	return vim.wo.spell
 end
 
-local function candidates(input, max_entries)
-  if #vim.spell.check(input) == 0 then
-    return {}
-  end
-
-  local entries = vim.fn.spellsuggest(input, max_entries)
-  local cands = {}
-  local text = vim.lsp.protocol.CompletionItemKind.Text
-
-  for i, entry in ipairs(entries) do
-    cands[i] = {
-      label = entry,
-      insertText = entry,
-      kind = text,
-      filterText = input,
-      sortText = ('_'):rep(i),
-    }
-  end
-  return cands
+---@param len integer
+---@return integer
+local function len_to_loglen(len)
+	return math.ceil(math.log10(len + 1))
 end
 
+---@param input string
+---@param number integer
+---@param loglen integer
+---@return string
+local function number_to_text(input, number, loglen)
+	return string.format(input .. "%0" .. loglen .. "d", number)
+end
+
+---@param input string
+---@param src blink-cmp-spell.Source
+---@return table
+local function candidates(input, src)
+	local items = {}
+	local entries = vim.fn.spellsuggest(input, src.max_entries)
+	local offset
+	local loglen
+	if src.preselect_correct_word and vim.tbl_isempty(vim.spell.check(input)) then
+		offset = 1
+		loglen = len_to_loglen(#entries + offset)
+
+		items[offset] = {
+			label = input,
+			filterText = input,
+			sortText = number_to_text(input, offset, loglen),
+			preselct = true,
+		}
+	else
+		offset = 0
+		loglen = len_to_loglen(#entries + offset)
+	end
+
+	for k, v in ipairs(entries) do
+		items[k + offset] = {
+			label = v,
+			filterText = src.keep_all_entries and input or v,
+			sortText = src.keep_all_entries and number_to_text(input, k + offset, loglen) or v,
+			preselct = false,
+		}
+	end
+
+	return items
+end
+
+---@param context blink.cmp.Context
+---@param callback blink.cmp.CompletionResponse
 function M:get_completions(context, callback)
-  vim.schedule(function()
-    local input = string.sub(
-      context.line,
-      context.bounds.start_col,
-      context.bounds.start_col + context.bounds.length - 1
-    )
-    if self.enable_in_context(context) then
-      callback {
-        items = candidates(input, self.max_entries),
-        is_incomplete_forward = true,
-        is_incomplete_backward = true,
-      }
-    else
-      callback {
-        items = {},
-        is_incomplete_forward = true,
-        is_incomplete_backward = true,
-      }
-    end
-  end)
+	vim.schedule(function()
+		local input =
+			string.sub(context.line, context.bounds.start_col, context.bounds.start_col + context.bounds.length - 1)
+		if self.enable_in_context(context) then
+			callback({
+				items = candidates(input, self),
+				is_incomplete_forward = true,
+				is_incomplete_backward = true,
+			})
+		else
+			callback({
+				items = {},
+				is_incomplete_forward = true,
+				is_incomplete_backward = true,
+			})
+		end
+	end)
 end
 
 return M


### PR DESCRIPTION
This fully matches the behaviour of `cmp-spell` and closes #4.
Also adds full type annotations.