### PR TITLE
Add `cmp-spell` functionality

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,5 @@
+indent_width = 2
+indent_type = "Spaces"
+quote_style = "AutoPreferSingle"
+call_parentheses = "NoSingleTable"
+column_width = 80

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Neovim's `spellsuggest`.
 
 
     -- It is recommended to put the "label" sorter as the primary sorter for the
-    -- spell source
+    -- spell source.
+    -- If you set use_cmp_spell_sorting to true, you may want to skip this step.
     fuzzy = {
       sorts = {
         function(a, b)
@@ -74,11 +75,33 @@ Neovim's `spellsuggest`.
 
 The maximum number of results to be returned from the spellchecker.
 
+### `preselect_current_word` (`boolean`, default `true`)
+
+If true and the spelling of the word is correct, the word is displayed as the first entry
+and preselected.
+
+### `keep_all_entries` (`boolean`, default `false`)
+
+If true, all `vim.fn.spellsuggest` results are displayed in `blink`'s menu. Otherwise,
+they are filtered to only include fuzzy matches.
+
+### `use_cmp_spell_sorting` (`boolean`, default `false`)
+
+If true, then completion candidates will be sorted using the same algorithm used by
+`cmp-spell`. This can be helpful for sorting words that are partially typed. Otherwise,
+a custom sorting is used.
+
+> [!NOTE]
+> If this option is set to `true`, then it is recommended that the `fuzzy.sorts` table is
+> left to its default value.
+
 ### `enable_in_context` (`function`, default `function() return true end`)
 
 A function that, upon returning false, disables the completion source. This can
 be used to disable the spelling source when in a `@nospell` `treesitter`
 capture.
+
+
 
 ## Shoutout
 

--- a/lua/blink-cmp-spell/init.lua
+++ b/lua/blink-cmp-spell/init.lua
@@ -58,23 +58,24 @@ function M:candidates(input, max_entries)
 
   local entries = vim.fn.spellsuggest(input, max_entries)
 
-  if
-    self.preselect_current_word and vim.tbl_isempty(vim.spell.check(input))
-  then
-    offset = 1
-    loglen = len_to_loglen(#entries + offset)
-
-    cands[offset] = {
-      label = input,
-      insertText = input,
-      filterText = input,
-      kind = text_kind,
-      sortText = self.use_cmp_spell_sorting
-          and number_to_text(input, offset, loglen)
-        or '_',
-      preselect = true,
-    }
-
+  if vim.tbl_isempty(vim.spell.check(input)) then
+    if self.preselect_current_word then
+      offset = 1
+      loglen = len_to_loglen(#entries + offset)
+      cands[offset] = {
+        label = input,
+        insertText = input,
+        filterText = input,
+        kind = text_kind,
+        sortText = self.use_cmp_spell_sorting
+            and number_to_text(input, offset, loglen)
+          or '_',
+        preselect = true,
+      }
+    else
+      offset = 0
+      loglen = len_to_loglen(#entries + offset)
+    end
     if not self.keep_all_entries then
       return cands
     end

--- a/lua/blink-cmp-spell/init.lua
+++ b/lua/blink-cmp-spell/init.lua
@@ -2,48 +2,104 @@
 
 local defaults = {
   max_entries = 3,
+  preselect_current_word = true,
+  keep_all_entries = false,
+  use_cmp_spell_sorting = false,
   enable_in_context = function()
     return true
   end,
 }
 
 --- @class blink-cmp-spell.Source : blink.cmp.Source
+---@field max_entries integer
+---@field preselect_current_word boolean
+---@field keep_all_entries boolean
+---@field use_cmp_spell_sorting boolean
+---@field enable_in_context fun(ctx: blink.cmp.Context): boolean
 local M = {}
 
 function M.new(opts)
+  ---@type blink-cmp-spell.Source
   local config = vim.tbl_deep_extend('keep', opts or {}, defaults)
   vim.validate {
     max_entries = { config.max_entries, 'number' },
     enable_in_context = { config.enable_in_context, 'function' },
+    preselect_current_word = { config.preselect_current_word, 'boolean' },
+    keep_all_entries = { config.keep_all_entries, 'boolean' },
+    use_cmp_spell_sorting = { config.use_cmp_spell_sorting, 'boolean' },
   }
 
-  return setmetatable({
-    max_entries = config.max_entries,
-    enable_in_context = config.enable_in_context,
-  }, { __index = M })
+  return setmetatable(config, { __index = M })
 end
 
 function M:enabled()
   return vim.wo.spell
 end
 
-local function candidates(input, max_entries)
-  if #vim.spell.check(input) == 0 then
-    return {}
-  end
+---@param len integer
+---@return integer
+local function len_to_loglen(len)
+  return math.ceil(math.log10(len + 1))
+end
+
+---@param input string
+---@param number integer
+---@param loglen integer
+---@return string
+local function number_to_text(input, number, loglen)
+  return string.format(input .. '%0' .. loglen .. 'd', number)
+end
+
+function M:candidates(input, max_entries)
+  local cands = {}
+  local text_kind = vim.lsp.protocol.CompletionItemKind.Text
+  local offset = 0
+  local loglen = 0
 
   local entries = vim.fn.spellsuggest(input, max_entries)
-  local cands = {}
-  local text = vim.lsp.protocol.CompletionItemKind.Text
+
+  if
+    self.preselect_current_word and vim.tbl_isempty(vim.spell.check(input))
+  then
+    offset = 1
+    loglen = len_to_loglen(#entries + offset)
+
+    cands[offset] = {
+      label = input,
+      insertText = input,
+      filterText = input,
+      kind = text_kind,
+      sortText = self.use_cmp_spell_sorting
+          and number_to_text(input, offset, loglen)
+        or '_',
+      preselect = true,
+    }
+
+    if not self.keep_all_entries then
+      return cands
+    end
+  else
+    offset = 0
+    loglen = len_to_loglen(#entries + offset)
+  end
 
   for i, entry in ipairs(entries) do
+    i = i + offset
     cands[i] = {
       label = entry,
       insertText = entry,
-      kind = text,
+      kind = text_kind,
       filterText = input,
       sortText = ('_'):rep(i),
+      preselect = false,
     }
+
+    if self.use_cmp_spell_sorting then
+      cands[i].filterText = self.keep_all_entries and input or entry
+      cands[i].sortText = self.keep_all_entries
+          and number_to_text(input, i, loglen)
+        or entry
+    end
   end
   return cands
 end
@@ -57,7 +113,7 @@ function M:get_completions(context, callback)
     )
     if self.enable_in_context(context) then
       callback {
-        items = candidates(input, self.max_entries),
+        items = self:candidates(input, self.max_entries),
         is_incomplete_forward = true,
         is_incomplete_backward = true,
       }


### PR DESCRIPTION
This provides settings that enable compatibility with `cmp-spell` and closes #4.

This is a reset of #5.

To summarise:
This pull request adapts the changes you made in your branch while also providing a way to override the sorting algorithm to match the behaviour of `cmp-spell`.