### PR TITLE
Add an example to the README to disable the source by `'spelllang'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ Neovim's `spellsuggest`.
 }
 ```
 
+> [!NOTE]
+> `vim.fn.spellsuggest` is really slow for some languages, for example German.
+> You can selectively disable this source, when German is configured in
+> 'spelllang' like so:
+> ```lua
+> {
+>   -- ...
+>   spell = {
+>     enabled = function()
+>       return not vim.list_contains(vim.opt_local.spelllang:get(), "de")
+>     end
+>   }
+>   -- ...
+> }
+> ```
+
 ## Options
 
 ### `max_entries` (`integer`, default `3`)

--- a/README.md
+++ b/README.md
@@ -73,15 +73,40 @@ Neovim's `spellsuggest`.
 > `vim.fn.spellsuggest` is really slow for some languages, for example German.
 > You can selectively disable this source, when German is configured in
 > 'spelllang' like so:
+>
 > ```lua
+> --- @type table<integer, boolean?>
+> local spell_enabled_cache = {}
+> 
+> vim.api.nvim_create_autocmd('OptionSet', {
+>   group = vim.api.nvim_create_augroup('blink_cmp_spell', {}),
+>   desc = 'Reset the cache for enabling the spell source for blink.cmp.',
+>   pattern = 'spelllang',
+>   callback = function()
+>     spell_enabled_cache[vim.fn.bufnr()] = nil
+>   end,
+> })
+> 
 > {
->   -- ...
->   spell = {
->     enabled = function()
->       return not vim.list_contains(vim.opt_local.spelllang:get(), "de")
->     end
->   }
->   -- ...
+>   'saghen/blink.cmp',
+>   dependencies = { 'ribru17/blink-cmp-spell' },
+>   opts = {
+>     sources = {
+>       providers = {
+>         spell = {
+>           enabled = function()
+>             local bufnr = vim.fn.bufnr()
+>             local enabled = spell_cache[bufnr]
+>             if type(enabled) ~= 'boolean' then
+>               enabled = not vim.list_contains(vim.opt_local.spelllang:get(), 'de')
+>               spell_cache[bufnr] = enabled
+>             end
+>             return enabled
+>           end,
+>         },
+>       },
+>     },
+>   },
 > }
 > ```
 


### PR DESCRIPTION
I recently ran into the problem, that `vim.fn.spellsuggest` gets really slow for German. It took multiple seconds for it to return a result and during that the entire editor would hang. Setting async or a timeout on the spell source did nothing to prevent this. So I just had to disable the spell source in any buffer where "de" is in `'spelllang'`. This might be handy for other people as well, so here you are. 😄

See also: https://github.com/neovim/neovim/issues/13546